### PR TITLE
Update Dockerfile.jupyter.kafka

### DIFF
--- a/02.replicas.in.sync/Dockerfile.jupyter.kafka
+++ b/02.replicas.in.sync/Dockerfile.jupyter.kafka
@@ -4,7 +4,7 @@ USER root
 RUN apt-get update && \
     apt-get install -y openjdk-11-jre-headless
 
-ARG KAFKA_VERSION=3.7.0
+ARG KAFKA_VERSION=4.0.0
 WORKDIR /opt
 
 # Download Kafka to get CLI tools


### PR DESCRIPTION
Updated KAFKA_VERSION to the latest inside `Dockerfile.jupyter.kafka` to download valid `.tar.gz` file listed at [Kafka mirror](https://downloads.apache.org/kafka/).